### PR TITLE
修复 npm i -g @wxa/cli2 后执行 wxa2 create 报错问题

### DIFF
--- a/packages/wxa-cli/package.json
+++ b/packages/wxa-cli/package.json
@@ -57,6 +57,7 @@
     "find-cache-dir": "^1.0.0",
     "find-root": "^1.1.0",
     "globby": "^8.0.1",
+    "htmlparser2": "^4.0.0",
     "inquirer": "^6.2.0",
     "js-base64": "^2.4.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
package.json 缺少依赖，复现步骤:

```bash
npm i -g @wxa/cli2
wxa2 create
```

报错如下

```
Error: Cannot find module 'htmlparser2'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
    at Function.Module._load (internal/modules/cjs/loader.js:507:25)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:22:18)
    at Object.<anonymous> (/usr/local/lib/node_modules/@wxa/cli2/dist/compilers/xml.js:12:19)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
```