### PR TITLE
删除 /packages/compiler-sass/reademe.md 乱码

### DIFF
--- a/packages/wxa-compiler-sass/README.md
+++ b/packages/wxa-compiler-sass/README.md
@@ -17,7 +17,7 @@ module.exports = {
 }
 ```
 
-### 指定 sass 配置
+### 指定 sass 配置
 
 ```javascript
 // wxa.config.js


### PR DESCRIPTION
如图，BS控制字符在 github markdown 渲染后会显示为乱码

![image](https://user-images.githubusercontent.com/1666185/63245911-eb967d00-c293-11e9-9ce7-3644e5e5278b.png)
