### PR TITLE
[FIX] flatten data should use [] 

### DIFF
--- a/packages/wxa-core/src/diff/flatten.js
+++ b/packages/wxa-core/src/diff/flatten.js
@@ -25,7 +25,7 @@ function flatten(oldValue, newValue, diff, opts) {
         let newKey;
         let newChildValue = newValue[key];
 
-        newKey = prev ? prev + delimiter + key : key;
+        newKey = prev ? prev + '[\'' + key + '\']' : key;
 
         if (oldValue) {
             // hasValue, meaning that new value still contain old one.
@@ -38,6 +38,7 @@ function flatten(oldValue, newValue, diff, opts) {
                 ) &&
                 Object.keys(diffChildValue).some((key)=>diffChildValue[key]===void(0))
             ) {
+                // console.log(currentDepth, ' element deleted ', newKey);
                 // some array or object element have been deleted.
                 // return new array or object.
                 output[newKey] = newChildValue;
@@ -62,4 +63,4 @@ function flatten(oldValue, newValue, diff, opts) {
     return output;
   }
 
-  export default flatten;
+export default flatten;

--- a/packages/wxa-core/src/diff/flatten.js
+++ b/packages/wxa-core/src/diff/flatten.js
@@ -25,7 +25,9 @@ function flatten(oldValue, newValue, diff, opts) {
         let newKey;
         let newChildValue = newValue[key];
 
-        newKey = prev ? prev + '[\'' + key + '\']' : key;
+        // Only digits (0-9) can be put inside [] in the path string
+        newKey = prev ? /^\d+$/.test(key) ? prev + '[' + key + ']' : prev + delimiter + key : key;
+
 
         if (oldValue) {
             // hasValue, meaning that new value still contain old one.

--- a/packages/wxa-core/test/diff/diff.test.js
+++ b/packages/wxa-core/test/diff/diff.test.js
@@ -35,3 +35,21 @@ describe('get diff flatten data with this.data', ()=>{
         expect(bindDiff({name: 'genuifx', toString: ()=>{}})).toMatchObject({name: 'genuifx'});
     });
 });
+
+describe('diff array', ()=>{
+    let arr1 = [{a: 1, b: 2, c: 3}];
+
+    let arr2 = [{a: 1, b: 2}];
+
+    test('get diff properties', ()=>{
+        let page = {
+            data: {
+                x: arr1,
+            },
+        };
+
+        let pageDiff = diff.bind(page);
+
+        expect(pageDiff({x: arr2})).toMatchObject({'x[\'0\']': {a: 1, b: 2}});
+    });
+});

--- a/packages/wxa-core/test/diff/diff.test.js
+++ b/packages/wxa-core/test/diff/diff.test.js
@@ -50,6 +50,6 @@ describe('diff array', ()=>{
 
         let pageDiff = diff.bind(page);
 
-        expect(pageDiff({x: arr2})).toMatchObject({'x[\'0\']': {a: 1, b: 2}});
+        expect(pageDiff({x: arr2})).toMatchObject({'x[0]': {a: 1, b: 2}});
     });
 });

--- a/packages/wxa-core/test/diff/flatten.test.js
+++ b/packages/wxa-core/test/diff/flatten.test.js
@@ -20,7 +20,7 @@ describe('flatten object for wxa', ()=>{
                     b: 3,
                 },
             }
-        )).toMatchObject({'a[\'b\']': 3});
+        )).toMatchObject({'a.b': 3});
 
         expect(flatten(
             {
@@ -32,7 +32,7 @@ describe('flatten object for wxa', ()=>{
             {
                 a: {c: {d: 1}},
             }
-        )).toMatchObject({'a[\'c\'][\'d\']': 1});
+        )).toMatchObject({'a.c.d': 1});
 
         expect(flatten(
             {
@@ -53,7 +53,7 @@ describe('flatten object for wxa', ()=>{
                 },
                 score: 2000,
             }
-        )).toMatchObject({'userInfo[\'name\']': 'Genuifx', 'score': 2000});
+        )).toMatchObject({'userInfo.name': 'Genuifx', 'score': 2000});
     });
 
     test('normal object with array', ()=>{
@@ -76,7 +76,7 @@ describe('flatten object for wxa', ()=>{
                     '1': {b: 1},
                 },
             },
-        })).toMatchObject({'a[\'c\'][1][\'b\']': 1});
+        })).toMatchObject({'a.c[1].b': 1});
 
         expect(flatten(
             {
@@ -96,7 +96,7 @@ describe('flatten object for wxa', ()=>{
                     c: [1, 2, 3],
                 },
             }
-        )).toMatchObject({'a[\'c\']': [1, 2, 3]});
+        )).toMatchObject({'a.c': [1, 2, 3]});
 
         // delete
         expect(flatten(
@@ -119,7 +119,7 @@ describe('flatten object for wxa', ()=>{
                     },
                 },
             }
-        )).toMatchObject({'a[\'c\']': [1, 2]});
+        )).toMatchObject({'a.c': [1, 2]});
     });
 
     test('setting undefine to newValue', ()=>{

--- a/packages/wxa-core/test/diff/flatten.test.js
+++ b/packages/wxa-core/test/diff/flatten.test.js
@@ -20,7 +20,7 @@ describe('flatten object for wxa', ()=>{
                     b: 3,
                 },
             }
-        )).toMatchObject({'a.b': 3});
+        )).toMatchObject({'a[\'b\']': 3});
 
         expect(flatten(
             {
@@ -32,7 +32,7 @@ describe('flatten object for wxa', ()=>{
             {
                 a: {c: {d: 1}},
             }
-        )).toMatchObject({'a.c.d': 1});
+        )).toMatchObject({'a[\'c\'][\'d\']': 1});
 
         expect(flatten(
             {
@@ -53,7 +53,7 @@ describe('flatten object for wxa', ()=>{
                 },
                 score: 2000,
             }
-        )).toMatchObject({'userInfo.name': 'Genuifx', 'score': 2000});
+        )).toMatchObject({'userInfo[\'name\']': 'Genuifx', 'score': 2000});
     });
 
     test('normal object with array', ()=>{
@@ -76,7 +76,7 @@ describe('flatten object for wxa', ()=>{
                     '1': {b: 1},
                 },
             },
-        })).toMatchObject({'a.c[1].b': 1});
+        })).toMatchObject({'a[\'c\'][1][\'b\']': 1});
 
         expect(flatten(
             {
@@ -96,7 +96,7 @@ describe('flatten object for wxa', ()=>{
                     c: [1, 2, 3],
                 },
             }
-        )).toMatchObject({'a.c': [1, 2, 3]});
+        )).toMatchObject({'a[\'c\']': [1, 2, 3]});
 
         // delete
         expect(flatten(
@@ -119,7 +119,7 @@ describe('flatten object for wxa', ()=>{
                     },
                 },
             }
-        )).toMatchObject({'a.c': [1, 2]});
+        )).toMatchObject({'a[\'c\']': [1, 2]});
     });
 
     test('setting undefine to newValue', ()=>{


### PR DESCRIPTION
While flattening data in diff method, wxa incorrectly generates dot(a.0) data-path.  In some case, it works fine, but handling array it gets the wrong result in mini-program.

So, we change the data-path with a single regexp match, using `[]` in digits key and dot with others.