### PR TITLE
Fix #43

### DIFF
--- a/packages/wxa-cli/src/resolvers/ast/index.js
+++ b/packages/wxa-cli/src/resolvers/ast/index.js
@@ -130,6 +130,7 @@ export default class ASTManager {
                             break;
                         case ImportDeclaration:
                             path.get('source').replaceWith(t.stringLiteral(resolved));
+                            path.skip();
                             break;
                     }
                 } catch (e) {

--- a/packages/wxa-cli/src/resolvers/ast/index.js
+++ b/packages/wxa-cli/src/resolvers/ast/index.js
@@ -126,12 +126,12 @@ export default class ASTManager {
                         case StringLiteralRequire:
                             // path.replaceWithSourceString(`require("${resolved}")`);
                             path.replaceWith( template(`require(SOURCE)`)({SOURCE: t.stringLiteral(resolved)}) );
+                            path.stop();
                             break;
                         case ImportDeclaration:
                             path.get('source').replaceWith(t.stringLiteral(resolved));
                             break;
                     }
-                    path.stop();
                 } catch (e) {
                     logger.error('解析失败', e);
                     debug('resolve fail %O', e);


### PR DESCRIPTION
在处理顶层 path 时如果 `path.stop()` 会导致文件后面所有内容都不再处理。

`require()` 的语法必定处于一层 `ExpressionStatement` 下所以没有问题，node_modules 以外的 `import` 都会被转义为 `require()` 同样也没问题。

但 node_modules 文件夹下 babel 默认不处理，还保留着 `import` 语法，调用 stop 就导致跳过了整个 `body` 的处理。

![image](https://user-images.githubusercontent.com/1666185/72050124-66237000-32fb-11ea-9a4b-564267fcb9cc.png)